### PR TITLE
Arreglada dependencia con maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ CCBot is a friendly and highly configurable platform that allows monitoring of s
 7.	Execute startcentral.sh
 8.  If server IP address is equal to CENTRAL.IP it will ask you for the admin password
 9.  Navigate in your browser to http://localhost:8050 (default port).
+10. Login with the username ccbot using the password you wrote before.
+
+## Build
+1. Install and add to your CLASSPATH Maven 3. 
+2. Execute the make-distro.sh file from source code.

--- a/ccbot/make-distro.sh
+++ b/ccbot/make-distro.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+echo "Maven is required";
+mvn install:install-file -Dfile=./lib/commons-ssl-1.0.0.jar -DgroupId=commons-ssl -DartifactId=commons-ssl -Dversion=1.0.0 -Dpackaging=jar
 rm -rvf CCBOT3-distro*
 rm -v cbot.log*
 mkdir CCBOT3-distro


### PR DESCRIPTION
-Se arregla la instalación de commons-ssl desde maven.
-Se arregla actualiza el README para evitar este paso.